### PR TITLE
Fix lagging display of total score

### DIFF
--- a/qml/pages/Round.qml
+++ b/qml/pages/Round.qml
@@ -83,11 +83,6 @@ Page {
                 //console.log("basket one!!!)")
                 mainPage.totalplayerpar[q] = 0
             }
-            player.append({
-                              nickname: nickname[q],
-                              playersbasketpar: playersbasketpar[q],
-                              playerstotalpar: mainPage.totalplayerpar[q]
-                          })
         }
 
     }
@@ -133,8 +128,11 @@ Page {
         }
         if (status === PageStatus.Activating) {
             for (var q = 0; q < howmanyplayers; q++) {
-                player.setProperty(q, "playerstotalpar",
-                                   mainPage.totalplayerpar[q])
+                player.set(q, {
+                                  nickname: nickname[q],
+                                  playersbasketpar: playersbasketpar[q],
+                                  playerstotalpar: mainPage.totalplayerpar[q]
+                              })
             }
         }
         if (status === PageStatus.Deactivating) {

--- a/qml/pages/Round_Results.qml
+++ b/qml/pages/Round_Results.qml
@@ -40,13 +40,7 @@ Page {
 
     Component.onCompleted: {
         nickname = DB.getNickNameAddedSelected()
-        // append player model (nickname and playerstotalpar)
-        for (q = 0; q < howmanyplayers; q++) {
-            player.append({
-                              nickname: nickname[q],
-                              playerstotalpar: mainPage.totalplayerpar[q]
-                          })
-        }
+
         //calculate elapsed time and convert to sce,min
         var elapsed = new Date().getTime() - mainPage.start
         var minutes = parseInt((elapsed / (1000 * 60)) % 60)
@@ -101,9 +95,10 @@ Page {
         mainWindow.cover = roundCover
         if (status === PageStatus.Activating) {
             for (var q = 0; q < howmanyplayers; q++) {
-                totalparplayerend[q] = totalparplayer[q] - totalparr
-                player.setProperty(q, "playerstotalpar",
-                                   mainPage.totalplayerpar[q])
+                player.set(q, {
+                                  nickname: nickname[q],
+                                  playerstotalpar: mainPage.totalplayerpar[q]
+                              })
             }
         }
 


### PR DESCRIPTION
There seems to be some race condition between page activation/onCompletion with the creation of the player data, which results in each round incorrectly displaying the previous total. 

I tried changing the player list update to set instead of append and moving the whole thing to the onStatusChanged event. This change seems to resolve the issue without producing unwanted behaviour, though I'm not sure if this is the correct solution.